### PR TITLE
Added flower pot and decorated pot to blacklist

### DIFF
--- a/world/datapacks/lem.base/data/lem.base/interactables/default.json
+++ b/world/datapacks/lem.base/data/lem.base/interactables/default.json
@@ -23,6 +23,8 @@
         "brewing_stand",
         "respawn_anchor",
         "cauldron",
+        "flower_pot",
+        "decorated_pot",
         "white_bed",
         "orange_bed",
         "magenta_bed",


### PR DESCRIPTION
Made flower pots and decorated pots (now interactable since 1.20.2) non-interactable.